### PR TITLE
Bugfix/fallback typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sugar-env",
-  "version": "1.5.2",
+  "version": "1.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,11 +7,15 @@ interface IConversionFunction<T> {
 }
 
 function _getAs<T> (fn: IConversionFunction<T>) {
-  return (names: string | string[], fallback: Nullable<string>) => {
-    const value = get(names, fallback)
-    if (value === null) return value
+  function getAs (names: string | string[]): T | null
+  function getAs (names: string | string[], fallback: T): T
+  function getAs (names: string | string[], fallback: T | null = null) {
+    const value = get(names)
+    if (value === null) return fallback
     return fn(value)
   }
+
+  return getAs
 }
 
 /**
@@ -38,6 +42,8 @@ export function has (name: string): Boolean {
  * @return {String}                        Environment variable's value or
  *                                         fallback value.
  */
+export function get (names: string[] | string): Nullable<string>
+export function get<T> (names: string[] | string, fallback: T): string | T
 export function get (names: string[] | string, fallback: Nullable<string> = null): Nullable<string> {
   if (!Array.isArray(names)) return get([names], fallback)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,9 @@ interface IConversionFunction<T> {
 }
 
 function _getAs<T> (fn: IConversionFunction<T>) {
-  function getAs (names: string | string[]): T | null
+  function getAs (names: string | string[]): Nullable<T>
   function getAs (names: string | string[], fallback: T): T
-  function getAs (names: string | string[], fallback: T | null = null) {
+  function getAs (names: string | string[], fallback: Nullable<T> = null) {
     const value = get(names)
     if (value === null) return fallback
     return fn(value)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,12 +11,8 @@
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,
-    /* Generates corresponding '.d.ts' file. */
-    "declarationMap": true,
-    /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true,
-    /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "declarationMap": false,
+    "sourceMap": false,
     "outDir": "./dist",
     "removeComments": false,
     "downlevelIteration": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,13 +18,7 @@
     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "./dist",
-    /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    "removeComments": true,
-    /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    "removeComments": false,
     "downlevelIteration": true,
     /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
     // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,70 +1,19 @@
 {
   "compilerOptions": {
-    /* Basic Options */
     "target": "es2015",
-    /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",
-    /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     "lib": ["es2015", "es2015.promise", "es2015.promise", "es2018.promise", "es6", "es7"],
-    /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
     "declaration": true,
     "declarationMap": false,
     "sourceMap": false,
     "outDir": "./dist",
     "removeComments": false,
     "downlevelIteration": true,
-    /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-
-    /* Strict Type-Checking Options */
     "strict": true,
-    /* Enable all strict type-checking options. */
-    "noImplicitAny": true,
-    /* Raise error on expressions and declarations with an implied 'any' type. */
-    "strictNullChecks": true,
-    /* Enable strict null checks. */
-    "strictFunctionTypes": true,
-    /* Enable strict checking of function types. */
-    "strictBindCallApply": true,
-    /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
-    "strictPropertyInitialization": true,
-    /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-
-    /* Additional Checks */
     "noUnusedLocals": true,
-    /* Report errors on unused locals. */
     "noUnusedParameters": true,
-    /* Report errors on unused parameters. */
     "noImplicitReturns": true,
-    /* Report error when not all code paths in function return a value. */
     "noFallthroughCasesInSwitch": true,
-    /* Report errors for fallthrough cases in switch statement. */
-
-    /* Module Resolution Options */
-    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
-    // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-
-    /* Source Map Options */
-    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-
-    /* Experimental Options */
-    // "experimentalDecorators": true,
-    /* Enables experimental support for ES7 decorators. */
-    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+    "esModuleInterop": true
   }
 }


### PR DESCRIPTION
When we migrated to typescript, we've been having to use explicit type casting, even when using fallbacks, because all the functions would return nullable values, which caused stuff like this to fail:

```ts
const myString: string = env.get('SOME_ENV', 'fallback') // string | null is not assignable to string
```

This PR adds overloads to bot the `get` function and its subfunctions, so that, when you pass a fallback, null is never returned (unless the fallback itself is null).

So these now behave as expected:

```ts
const myString: string = env.get('SOME_ENV', 'fallback') // OK
const stringOrNul: string | null = env.get('SOME_ENV') // OK
const stringOrNumber: string | number = env.get('SOME_ENV', 10) // OK
const myNumber: number = env.get.int('SOME_ENV') // Fails because returned value can be null
const myActualNumber: number = env.get.int('SOME_ENV', 100) // OK
const yetAnotherNumber: number = env.get.int('SOME_ENV', 'lalala') // Fails because fallback is not of type number
```