### PR TITLE
Add deno port

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,21 @@ app.listen({ host, port }, () => {
 })
 ```
 
+### Usage with Deno
+
+You can use this with deno by importing the [mod.ts](mod.ts) file. The API is exactly the same.
+
+The Deno version will look for `DENO_ENV` instead of `NODE_ENV` when checking the current environment.
+
+**Requires `allow-env`**
+
 ## API
 
 - sugar-env:
     - **.concurrent: String**: returns the current environment name;
     - **.is(String environment): Boolean**: checks if the given environment matchs the current environment name;
     - **.get(Array[String]|String names, String fallback = null): String**: gets the given environment variable or returns the fallback value. If an array of environment variables is given, the value of the first one to be found is returned.
+
 
 ---
 

--- a/mod.ts
+++ b/mod.ts
@@ -1,0 +1,3 @@
+import deno from './src/deno.ts'
+
+export default deno

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -52,7 +52,7 @@ get.int = _getAs<number>((value) => parseInt(value, 10))
 get.float = _getAs<number>((value) => parseFloat(value))
 get.url = _getAs<string>((value) => value.endsWith('/') ? value : `${value} /`)
 
-const current = process.env.NODE_ENV || Environments.DEVELOPMENT
+const current = process.env.DENO_ENV || Environments.DEVELOPMENT
 
 const is = (environment: Environments): Boolean => {
   return current === environment

--- a/src/deno.ts
+++ b/src/deno.ts
@@ -1,0 +1,94 @@
+import Environments from './structures/environments.ts'
+import { Base64 } from 'https://deno.land/x/bb64/mod.ts'
+
+const process = {
+  env: Deno.env.toObject()
+}
+
+type Nullable<T> = T | null
+
+const has = (name: string): Boolean => {
+  return name in process.env
+    && typeof process.env[ name ] === 'string'
+    && (process.env[ name ] as string).length > 0
+}
+
+function get (names: string[] | string): Nullable<string>
+function get<T> (names: string[] | string, fallback: T): T
+function get (names: string[] | string, fallback: Nullable<string> = null): Nullable<string> {
+  if (!Array.isArray(names)) return get([ names ], fallback)
+
+  const value = names.filter(name => has(name))
+    .map(name => process.env[ name ])
+    .shift()
+
+  if (!value) return fallback !== null ? fallback.toString() : fallback
+
+  return value
+}
+
+interface IConversionFunction<T> {
+  (value: string): Nullable<T>
+}
+
+function _getAs<T> (fn: IConversionFunction<T>) {
+  function getAs (names: string | string[]): Nullable<T>
+  function getAs (names: string | string[], fallback: T): T
+  function getAs (names: string | string[], fallback: Nullable<T> = null) {
+    const value = get(names)
+    if (value === null) {
+      return fallback
+    }
+
+    return fn(value)
+  }
+
+  return getAs
+}
+
+get.base64 = _getAs<string>((value) => Base64.fromBase64String(value).toString())
+get.boolean = _getAs<boolean>((value) => [ '1', 'true' ].includes(value.toLowerCase()))
+get.int = _getAs<number>((value) => parseInt(value, 10))
+get.float = _getAs<number>((value) => parseFloat(value))
+get.url = _getAs<string>((value) => value.endsWith('/') ? value : `${value} /`)
+
+const current = process.env.NODE_ENV || Environments.DEVELOPMENT
+
+const is = (environment: Environments): Boolean => {
+  return current === environment
+}
+
+const entrypoint = (current: Environments): { is: (x: Environments) => boolean } => ({
+  is: (environment: Environments) => current === environment
+})
+
+entrypoint.is = is
+entrypoint.get = get
+entrypoint.has = has
+entrypoint.current = current
+
+const TEST = Environments.TEST
+const REVIEW = Environments.REVIEW
+const STAGING = Environments.STAGING
+const PRODUCTION = Environments.PRODUCTION
+const DEVELOPMENT = Environments.DEVELOPMENT
+
+entrypoint.TEST = TEST
+entrypoint.REVIEW = REVIEW
+entrypoint.STAGING = STAGING
+entrypoint.PRODUCTION = PRODUCTION
+entrypoint.DEVELOPMENT = DEVELOPMENT
+
+export {
+  has,
+  get,
+  is,
+  current,
+  TEST,
+  REVIEW,
+  STAGING,
+  PRODUCTION,
+  DEVELOPMENT
+}
+
+export default entrypoint


### PR DESCRIPTION
This adds a `mod.ts` file, pointing to a deno-compatible version.
I have future plans on merging the two implementations by abstracting the differences between them but, untill I get to it, this will suffice.